### PR TITLE
Change user_id column type to bigInteger

### DIFF
--- a/migrations/create_brick_devices_table.php.stub
+++ b/migrations/create_brick_devices_table.php.stub
@@ -12,8 +12,7 @@ class CreateBrickDevicesTable extends Migration
     {
         Schema::create('brick_devices', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreignId('user_id')->constrained('users');
             $table->string('device_id')->unique();
             $table->timestamps();
         });

--- a/migrations/create_brick_devices_table.php.stub
+++ b/migrations/create_brick_devices_table.php.stub
@@ -11,7 +11,7 @@ class CreateBrickDevicesTable extends Migration
     public function up()
     {
         Schema::create('brick_devices', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
             $table->foreignId('user_id')->constrained('users');
             $table->string('device_id')->unique();
             $table->timestamps();


### PR DESCRIPTION
This PR changes the user_id column type from `integer` to `bigInteger` via `foreignId`. 
BigInteger is the column type used in ``$table->id()`` which is also the default when creating a fresh Laravel application.